### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "swift"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # code-blue
 A mental health app for YC students. (CAS Project 2020)
+
+[![Run on Repl.it](https://repl.it/badge/github/mee-kell/code-blue)](https://repl.it/github/mee-kell/code-blue)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@meekell/code-blue).